### PR TITLE
Removing dead links

### DIFF
--- a/_data/jobs.yml
+++ b/_data/jobs.yml
@@ -2,18 +2,6 @@
 #   company: "Company"
 #   url: "URL to additional details"
 
- - title: "Senior Software Engineer"
-   company: "Denim Labs, Inc"
-   url: "https://www.denimlabs.com/careers/senior-software-engineer/"
-
- - title: "Software Engineer"
-   company: "Denim Labs, Inc"
-   url: "https://www.denimlabs.com/careers/software-engineer/"
-
- - title: "Senior Engineer - Web Operations"
-   company: "Meredith Corporation"
-   url: "https://meredith.wd5.myworkdayjobs.com/en-US/EXT/job/Iowa-Des-Moines/Sr-Engineer---Web-Operations_JR04903"
-
  - title: "Salesforce Application Developer"
    company: "Orchestrate LLC"
    url: "https://docs.google.com/document/d/1mnnL4NaEE6GqjWkIAIk4gjkNPzUlznShl6HkhBaEdXk/pub"


### PR DESCRIPTION
Some of these links don't lead anywhere. Assuming roles have been filled or are no longer looking.